### PR TITLE
Update globals.css

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -11,6 +11,7 @@ body {
     font-family: Roboto, sans-serif;
     background: #000;
     overscroll-behavior-y: none;
+    overflow-y: scroll;
 }
 
 a {


### PR DESCRIPTION
scrollbars disappear when switching routes, just a little touch as the css specification defines this as well, you should use scroll to prevent the page from bouncing around when you change routes. maybe add some webkit scrollbar styles too? though you likely left it unstyled by preference

i made this PR on the old repo that you forgot to archive believing that one was the one that is currently on your site, so yeah you can merge it on this one as well and you'll be good to go