### PR TITLE
Fix scrollbar issue

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -13,6 +13,10 @@ body {
     overscroll-behavior-y: none;
 }
 
+html {
+    overflow-y: scroll;
+}
+
 a {
     color: inherit;
     text-decoration: none;


### PR DESCRIPTION
scrollbars disappear when switching routes, just a little touch as the css specification defines this as well, you should use scroll to prevent the page from bouncing around when you change routes. maybe add some webkit scrollbar styles too? though you likely left it unstyled by preference

i made this PR on the old repo that you forgot to archive believing that one was the one that is currently on your site, so yeah you can merge it on this one as well and you'll be good to go